### PR TITLE
Fix logo references and profile photo

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,7 +13,7 @@
   <header>
     <div class="header-content">
       <a href="index.html" class="logo" aria-label="Oli Rose Home">
-        <img class="logo-img" src="images/logo.png" alt="Oliver Rose Logo"
+        <img class="logo-img" src="images/Rose Above Logo.png" alt="Oliver Rose Logo"
           onerror="this.style.display='none';this.insertAdjacentHTML('afterend',`<svg width='48' height='48' aria-label='OR'><rect width='48' height='48' fill='#fff'/><text x='50%' y='55%' dominant-baseline='middle' text-anchor='middle' font-size='18' fill='#222' font-family='Montserrat,sans-serif'>OR</text></svg>`);" />
         <span class="logo-title">OLIVER<br>ROSE</span>
       </a>
@@ -37,7 +37,7 @@
       <h1 class="section-title">About Oliver</h1>
       <div class="about-flex">
         <div class="about-img">
-          <img src="images/oliver-profile.jpg" alt="Oliver Rose smiling, wearing headphones, in a creative workspace">
+          <img src="images/oliver-profile.png" alt="Oliver Rose smiling, wearing headphones, in a creative workspace">
         </div>
         <div class="about-text">
           <p>

--- a/contact.html
+++ b/contact.html
@@ -13,7 +13,7 @@
   <header>
     <div class="header-content">
       <a href="index.html" class="logo" aria-label="Oli Rose Home">
-        <img class="logo-img" src="images/logo.png" alt="Oliver Rose Logo"
+        <img class="logo-img" src="images/Rose Above Logo.png" alt="Oliver Rose Logo"
           onerror="this.style.display='none';this.insertAdjacentHTML('afterend',`<svg width='48' height='48' aria-label='OR'><rect width='48' height='48' fill='#fff'/><text x='50%' y='55%' dominant-baseline='middle' text-anchor='middle' font-size='18' fill='#222' font-family='Montserrat,sans-serif'>OR</text></svg>`);" />
         <span class="logo-title">OLIVER<br>ROSE</span>
       </a>

--- a/portfolio.html
+++ b/portfolio.html
@@ -13,7 +13,7 @@
   <header>
     <div class="header-content">
       <a href="index.html" class="logo" aria-label="Oli Rose Home">
-        <img class="logo-img" src="images/logo.png" alt="Oliver Rose Logo"
+        <img class="logo-img" src="images/Rose Above Logo.png" alt="Oliver Rose Logo"
           onerror="this.style.display='none';this.insertAdjacentHTML('afterend',`<svg width='48' height='48' aria-label='OR'><rect width='48' height='48' fill='#fff'/><text x='50%' y='55%' dominant-baseline='middle' text-anchor='middle' font-size='18' fill='#222' font-family='Montserrat,sans-serif'>OR</text></svg>`);" />
         <span class="logo-title">OLIVER<br>ROSE</span>
       </a>

--- a/privacy.html
+++ b/privacy.html
@@ -13,7 +13,7 @@
   <header>
     <div class="header-content">
       <a href="index.html" class="logo" aria-label="Oli Rose Home">
-        <img class="logo-img" src="images/logo.png" alt="Oliver Rose Logo"
+        <img class="logo-img" src="images/Rose Above Logo.png" alt="Oliver Rose Logo"
           onerror="this.style.display='none';this.insertAdjacentHTML('afterend',`<svg width='48' height='48' aria-label='OR'><rect width='48' height='48' fill='#fff'/><text x='50%' y='55%' dominant-baseline='middle' text-anchor='middle' font-size='18' fill='#222' font-family='Montserrat,sans-serif'>OR</text></svg>`);" />
         <span class="logo-title">OLIVER<br>ROSE</span>
       </a>

--- a/services.html
+++ b/services.html
@@ -14,7 +14,7 @@
   <header>
     <div class="header-content">
       <a href="index.html" class="logo" aria-label="Oli Rose Home">
-        <img class="logo-img" src="images/logo.png" alt="Oliver Rose Logo"
+        <img class="logo-img" src="images/Rose Above Logo.png" alt="Oliver Rose Logo"
           onerror="this.style.display='none';this.insertAdjacentHTML('afterend',`<svg width='48' height='48' aria-label='OR'><rect width='48' height='48' fill='#fff'/><text x='50%' y='55%' dominant-baseline='middle' text-anchor='middle' font-size='18' fill='#222' font-family='Montserrat,sans-serif'>OR</text></svg>`);" />
         <span class="logo-title">OLIVER<br>ROSE</span>
       </a>

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const urlsToCache = [
   '/portfolio.html',
   '/css/style.css',
   '/js/main.js',
-  '/images/logo.png' // add other assets as needed...
+  '/images/Rose Above Logo.png' // add other assets as needed...
 ];
 
 self.addEventListener('install', function(event) {

--- a/terms.html
+++ b/terms.html
@@ -13,7 +13,7 @@
   <header>
     <div class="header-content">
       <a href="index.html" class="logo" aria-label="Oli Rose Home">
-        <img class="logo-img" src="images/logo.png" alt="Oliver Rose Logo"
+        <img class="logo-img" src="images/Rose Above Logo.png" alt="Oliver Rose Logo"
           onerror="this.style.display='none';this.insertAdjacentHTML('afterend',`<svg width='48' height='48' aria-label='OR'><rect width='48' height='48' fill='#fff'/><text x='50%' y='55%' dominant-baseline='middle' text-anchor='middle' font-size='18' fill='#222' font-family='Montserrat,sans-serif'>OR</text></svg>`);" />
         <span class="logo-title">OLIVER<br>ROSE</span>
       </a>


### PR DESCRIPTION
## Summary
- update all logo references to use `Rose Above Logo.png`
- switch the About page profile image to `oliver-profile.png`
- update `sw.js` cache list for new logo filename

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6864073c2c7c832e94ac7557a184c4ba