### PR TITLE
Add improved head sections for secondary pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,10 +2,18 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Page Not Found - Rose Above Accountancy</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Page Not Found - Rose Above Accountancy</title>
+  <meta name="description" content="The page you're looking for cannot be found." />
   <link rel="canonical" href="https://roseaboveaccountancy.co.uk/404.html" />
-  <link rel="stylesheet" href="css/style.css">
+  <meta name="author" content="Oliver Rose">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
   <main style="padding:2em;text-align:center;">

--- a/about.html
+++ b/about.html
@@ -2,12 +2,18 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>About Oliver Rose | Finance for Musicians & Creatives</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<link rel="canonical" href="https://roseaboveaccountancy.co.uk/about.html" />
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="icon" href="images/favicon.ico">
-  <script src="https://kit.fontawesome.com/fe7fbe4e2b.js" crossorigin="anonymous"></script>
+  <meta name="description" content="About Oliver Rose – finance and business support for musicians and creatives." />
+  <link rel="canonical" href="https://roseaboveaccountancy.co.uk/about.html" />
+  <meta name="author" content="Oliver Rose">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
   <header>

--- a/contact.html
+++ b/contact.html
@@ -2,12 +2,18 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Contact | Oliver Rose Finance for Musicians & Creatives</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<link rel="canonical" href="https://roseaboveaccountancy.co.uk/contact.html" />
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="icon" href="images/favicon.ico">
-  <script src="https://kit.fontawesome.com/fe7fbe4e2b.js" crossorigin="anonymous"></script>
+  <meta name="description" content="Contact Oliver Rose for finance and tax support for musicians and creatives." />
+  <link rel="canonical" href="https://roseaboveaccountancy.co.uk/contact.html" />
+  <meta name="author" content="Oliver Rose">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
   <header>

--- a/portfolio.html
+++ b/portfolio.html
@@ -2,12 +2,18 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Portfolio | Oliver Rose Finance for Musicians & Creatives</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<link rel="canonical" href="https://roseaboveaccountancy.co.uk/portfolio.html" />
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="icon" href="images/favicon.ico">
-  <script src="https://kit.fontawesome.com/fe7fbe4e2b.js" crossorigin="anonymous"></script>
+  <meta name="description" content="Portfolio of work supporting musicians and creative businesses." />
+  <link rel="canonical" href="https://roseaboveaccountancy.co.uk/portfolio.html" />
+  <meta name="author" content="Oliver Rose">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
   <header>

--- a/privacy.html
+++ b/privacy.html
@@ -2,12 +2,18 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Privacy Policy | Oliver Rose Finance</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<link rel="canonical" href="https://roseaboveaccountancy.co.uk/privacy.html" />
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="icon" href="images/favicon.ico">
-  <script src="https://kit.fontawesome.com/fe7fbe4e2b.js" crossorigin="anonymous"></script>
+  <meta name="description" content="Privacy policy for Rose Above Accountancy." />
+  <link rel="canonical" href="https://roseaboveaccountancy.co.uk/privacy.html" />
+  <meta name="author" content="Oliver Rose">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
   <header>

--- a/services.html
+++ b/services.html
@@ -2,13 +2,18 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link rel="canonical" href="https://roseaboveaccountancy.co.uk/services.html" />
+  <link rel="canonical" href="https://roseaboveaccountancy.co.uk/services.html" />
   <title>Our Services | Oliver's Finance for Musicians</title>
   <meta name="description" content="Our Services – Oliver's Finance for Musicians" />
-  <link rel="stylesheet" href="css/style.css" />
-  <link rel="icon" href="images/favicon.ico">
-  <script src="https://kit.fontawesome.com/fe7fbe4e2b.js" crossorigin="anonymous"></script>
+  <meta name="author" content="Oliver Rose">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
   <header>

--- a/terms.html
+++ b/terms.html
@@ -2,12 +2,18 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Terms & Conditions | Oliver Rose Finance</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<link rel="canonical" href="https://roseaboveaccountancy.co.uk/terms.html" />
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="icon" href="images/favicon.ico">
-  <script src="https://kit.fontawesome.com/fe7fbe4e2b.js" crossorigin="anonymous"></script>
+  <meta name="description" content="Terms and conditions for using Rose Above Accountancy." />
+  <link rel="canonical" href="https://roseaboveaccountancy.co.uk/terms.html" />
+  <meta name="author" content="Oliver Rose">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
   <header>

--- a/thankyou.html
+++ b/thankyou.html
@@ -2,9 +2,18 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-<link rel="canonical" href="https://roseaboveaccountancy.co.uk/thankyou.html" />
+  <link rel="canonical" href="https://roseaboveaccountancy.co.uk/thankyou.html" />
   <title>Thank You!</title>
+  <meta name="description" content="Thank you for getting in touch with Oliver Rose." />
+  <meta name="author" content="Oliver Rose">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <style>
     body {
       font-family: Arial, sans-serif;


### PR DESCRIPTION
## Summary
- match `index.html` metadata and fonts on all other HTML pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68640c314db8832e9faa653ba85d3daf