### PR TITLE
Add open graph meta and accessibility features

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,16 +2,32 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Page Not Found - Rose Above Accountancy</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Page Not Found - Rose Above Accountancy</title>
+  <meta name="description" content="The page you're looking for cannot be found." />
   <link rel="canonical" href="https://roseaboveaccountancy.co.uk/404.html" />
-  <link rel="stylesheet" href="css/style.css">
+  <meta name="author" content="Oliver Rose">
+  <meta property="og:title" content="Page Not Found - Rose Above Accountancy">
+  <meta property="og:description" content="The page you're looking for cannot be found.">
+  <meta property="og:image" content="https://roseaboveaccountancy.co.uk/images/Rose%20Above%20Logo.png">
+  <meta property="og:url" content="https://roseaboveaccountancy.co.uk/404.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
-  <main style="padding:2em;text-align:center;">
+  <a href="#mainContent" class="skip-link">Skip to main content</a>
+  <main id="mainContent" tabindex="-1" style="padding:2em;text-align:center;">
     <h1>404 - Page Not Found</h1>
     <p>The page you requested could not be found.</p>
     <a href="index.html" class="btn">Return Home</a>
   </main>
+  <button id="backToTop" aria-label="Back to top"><i class="fa-solid fa-arrow-up"></i></button>
+  <script src="js/main.js?v=20250611" defer></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -2,14 +2,26 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>About Oliver Rose | Finance for Musicians & Creatives</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<link rel="canonical" href="https://roseaboveaccountancy.co.uk/about.html" />
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="icon" href="images/favicon.ico">
-  <script src="https://kit.fontawesome.com/fe7fbe4e2b.js" crossorigin="anonymous"></script>
+  <meta name="description" content="About Oliver Rose – finance and business support for musicians and creatives." />
+  <link rel="canonical" href="https://roseaboveaccountancy.co.uk/about.html" />
+  <meta name="author" content="Oliver Rose">
+  <meta property="og:title" content="About Oliver Rose | Finance for Musicians & Creatives">
+  <meta property="og:description" content="About Oliver Rose – finance and business support for musicians and creatives.">
+  <meta property="og:image" content="https://roseaboveaccountancy.co.uk/images/Rose%20Above%20Logo.png">
+  <meta property="og:url" content="https://roseaboveaccountancy.co.uk/about.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
+  <a href="#mainContent" class="skip-link">Skip to main content</a>
   <header>
     <div class="header-content">
       <a href="index.html" class="logo" aria-label="Oli Rose Home">
@@ -28,9 +40,18 @@
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
+      <div class="header-controls">
+        <button id="themeToggleBtn" class="theme-toggle" aria-label="Toggle dark or light mode">
+          <span class="theme-toggle-icon"><i class="fa-solid fa-moon"></i></span>
+          <span class="theme-toggle-text">Dark</span>
+        </button>
+        <button class="hamburger" aria-label="Open navigation menu" aria-expanded="false">
+          <span></span><span></span><span></span>
+        </button>
+      </div>
     </div>
   </header>
-  <main class="main-container" style="max-width:800px;">
+  <main id="mainContent" tabindex="-1" class="main-container" style="max-width:800px;">
     <div class="ska-accent"></div>
     <section>
       <span class="section-subtitle">Who I Am</span>
@@ -89,5 +110,7 @@
       </div>
     </div>
   </footer>
+  <button id="backToTop" aria-label="Back to top"><i class="fa-solid fa-arrow-up"></i></button>
+  <script src="js/main.js?v=20250611" defer></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -2,14 +2,26 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Contact | Oliver Rose Finance for Musicians & Creatives</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<link rel="canonical" href="https://roseaboveaccountancy.co.uk/contact.html" />
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="icon" href="images/favicon.ico">
-  <script src="https://kit.fontawesome.com/fe7fbe4e2b.js" crossorigin="anonymous"></script>
+  <meta name="description" content="Contact Oliver Rose for finance and tax support for musicians and creatives." />
+  <link rel="canonical" href="https://roseaboveaccountancy.co.uk/contact.html" />
+  <meta name="author" content="Oliver Rose">
+  <meta property="og:title" content="Contact | Oliver Rose Finance for Musicians & Creatives">
+  <meta property="og:description" content="Contact Oliver Rose for finance and tax support for musicians and creatives.">
+  <meta property="og:image" content="https://roseaboveaccountancy.co.uk/images/Rose%20Above%20Logo.png">
+  <meta property="og:url" content="https://roseaboveaccountancy.co.uk/contact.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
+  <a href="#mainContent" class="skip-link">Skip to main content</a>
   <header>
     <div class="header-content">
       <a href="index.html" class="logo" aria-label="Oli Rose Home">
@@ -28,9 +40,18 @@
           <li><a href="contact.html" class="nav-link active">Contact</a></li>
         </ul>
       </nav>
+      <div class="header-controls">
+        <button id="themeToggleBtn" class="theme-toggle" aria-label="Toggle dark or light mode">
+          <span class="theme-toggle-icon"><i class="fa-solid fa-moon"></i></span>
+          <span class="theme-toggle-text">Dark</span>
+        </button>
+        <button class="hamburger" aria-label="Open navigation menu" aria-expanded="false">
+          <span></span><span></span><span></span>
+        </button>
+      </div>
     </div>
   </header>
-  <main class="main-container" style="max-width:650px;">
+  <main id="mainContent" tabindex="-1" class="main-container" style="max-width:650px;">
     <div class="ska-accent"></div>
     <section id="contact">
       <span class="section-subtitle">Let’s Talk</span>
@@ -94,5 +115,7 @@
       </div>
     </div>
   </footer>
+  <button id="backToTop" aria-label="Back to top"><i class="fa-solid fa-arrow-up"></i></button>
+  <script src="js/main.js?v=20250611" defer></script>
 </body>
 </html>

--- a/portfolio.html
+++ b/portfolio.html
@@ -2,14 +2,26 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Portfolio | Oliver Rose Finance for Musicians & Creatives</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<link rel="canonical" href="https://roseaboveaccountancy.co.uk/portfolio.html" />
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="icon" href="images/favicon.ico">
-  <script src="https://kit.fontawesome.com/fe7fbe4e2b.js" crossorigin="anonymous"></script>
+  <meta name="description" content="Portfolio of work supporting musicians and creative businesses." />
+  <link rel="canonical" href="https://roseaboveaccountancy.co.uk/portfolio.html" />
+  <meta name="author" content="Oliver Rose">
+  <meta property="og:title" content="Portfolio | Oliver Rose Finance for Musicians & Creatives">
+  <meta property="og:description" content="Portfolio of work supporting musicians and creative businesses.">
+  <meta property="og:image" content="https://roseaboveaccountancy.co.uk/images/Rose%20Above%20Logo.png">
+  <meta property="og:url" content="https://roseaboveaccountancy.co.uk/portfolio.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
+  <a href="#mainContent" class="skip-link">Skip to main content</a>
   <header>
     <div class="header-content">
       <a href="index.html" class="logo" aria-label="Oli Rose Home">
@@ -28,9 +40,18 @@
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
+      <div class="header-controls">
+        <button id="themeToggleBtn" class="theme-toggle" aria-label="Toggle dark or light mode">
+          <span class="theme-toggle-icon"><i class="fa-solid fa-moon"></i></span>
+          <span class="theme-toggle-text">Dark</span>
+        </button>
+        <button class="hamburger" aria-label="Open navigation menu" aria-expanded="false">
+          <span></span><span></span><span></span>
+        </button>
+      </div>
     </div>
   </header>
-  <main class="main-container" style="max-width:900px;">
+  <main id="mainContent" tabindex="-1" class="main-container" style="max-width:900px;">
     <div class="ska-accent"></div>
     <section>
       <span class="section-subtitle">Showcase</span>
@@ -84,5 +105,7 @@
       </div>
     </div>
   </footer>
+  <button id="backToTop" aria-label="Back to top"><i class="fa-solid fa-arrow-up"></i></button>
+  <script src="js/main.js?v=20250611" defer></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -2,14 +2,26 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Privacy Policy | Oliver Rose Finance</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<link rel="canonical" href="https://roseaboveaccountancy.co.uk/privacy.html" />
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="icon" href="images/favicon.ico">
-  <script src="https://kit.fontawesome.com/fe7fbe4e2b.js" crossorigin="anonymous"></script>
+  <meta name="description" content="Privacy policy for Rose Above Accountancy." />
+  <link rel="canonical" href="https://roseaboveaccountancy.co.uk/privacy.html" />
+  <meta name="author" content="Oliver Rose">
+  <meta property="og:title" content="Privacy Policy | Oliver Rose Finance">
+  <meta property="og:description" content="Privacy policy for Rose Above Accountancy.">
+  <meta property="og:image" content="https://roseaboveaccountancy.co.uk/images/Rose%20Above%20Logo.png">
+  <meta property="og:url" content="https://roseaboveaccountancy.co.uk/privacy.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
+  <a href="#mainContent" class="skip-link">Skip to main content</a>
   <header>
     <div class="header-content">
       <a href="index.html" class="logo" aria-label="Oli Rose Home">
@@ -28,9 +40,18 @@
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
+      <div class="header-controls">
+        <button id="themeToggleBtn" class="theme-toggle" aria-label="Toggle dark or light mode">
+          <span class="theme-toggle-icon"><i class="fa-solid fa-moon"></i></span>
+          <span class="theme-toggle-text">Dark</span>
+        </button>
+        <button class="hamburger" aria-label="Open navigation menu" aria-expanded="false">
+          <span></span><span></span><span></span>
+        </button>
+      </div>
     </div>
   </header>
-  <main class="main-container" style="max-width:700px;margin:auto;padding:2em 1em;">
+  <main id="mainContent" tabindex="-1" class="main-container" style="max-width:700px;margin:auto;padding:2em 1em;">
     <div class="ska-accent"></div>
     <h1 class="section-title">Privacy Policy</h1>
     <h2>Introduction</h2>
@@ -82,5 +103,7 @@
       </div>
     </div>
   </footer>
+  <button id="backToTop" aria-label="Back to top"><i class="fa-solid fa-arrow-up"></i></button>
+  <script src="js/main.js?v=20250611" defer></script>
 </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -2,15 +2,26 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link rel="canonical" href="https://roseaboveaccountancy.co.uk/services.html" />
+  <link rel="canonical" href="https://roseaboveaccountancy.co.uk/services.html" />
   <title>Our Services | Oliver's Finance for Musicians</title>
   <meta name="description" content="Our Services – Oliver's Finance for Musicians" />
-  <link rel="stylesheet" href="css/style.css" />
-  <link rel="icon" href="images/favicon.ico">
-  <script src="https://kit.fontawesome.com/fe7fbe4e2b.js" crossorigin="anonymous"></script>
+  <meta name="author" content="Oliver Rose">
+  <meta property="og:title" content="Our Services | Oliver's Finance for Musicians">
+  <meta property="og:description" content="Our Services – Oliver's Finance for Musicians">
+  <meta property="og:image" content="https://roseaboveaccountancy.co.uk/images/Rose%20Above%20Logo.png">
+  <meta property="og:url" content="https://roseaboveaccountancy.co.uk/services.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
+  <a href="#mainContent" class="skip-link">Skip to main content</a>
   <header>
     <div class="header-content">
       <a href="index.html" class="logo" aria-label="Oli Rose Home">
@@ -29,9 +40,18 @@
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
+      <div class="header-controls">
+        <button id="themeToggleBtn" class="theme-toggle" aria-label="Toggle dark or light mode">
+          <span class="theme-toggle-icon"><i class="fa-solid fa-moon"></i></span>
+          <span class="theme-toggle-text">Dark</span>
+        </button>
+        <button class="hamburger" aria-label="Open navigation menu" aria-expanded="false">
+          <span></span><span></span><span></span>
+        </button>
+      </div>
     </div>
   </header>
-  <main class="main-container">
+  <main id="mainContent" tabindex="-1" class="main-container">
     <div class="ska-accent"></div>
     <section id="our-services" class="fade-in">
       <span class="section-subtitle">What I Offer</span>
@@ -85,5 +105,7 @@
       </div>
     </div>
   </footer>
+  <button id="backToTop" aria-label="Back to top"><i class="fa-solid fa-arrow-up"></i></button>
+  <script src="js/main.js?v=20250611" defer></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -2,14 +2,26 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Terms & Conditions | Oliver Rose Finance</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<link rel="canonical" href="https://roseaboveaccountancy.co.uk/terms.html" />
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="icon" href="images/favicon.ico">
-  <script src="https://kit.fontawesome.com/fe7fbe4e2b.js" crossorigin="anonymous"></script>
+  <meta name="description" content="Terms and conditions for using Rose Above Accountancy." />
+  <link rel="canonical" href="https://roseaboveaccountancy.co.uk/terms.html" />
+  <meta name="author" content="Oliver Rose">
+  <meta property="og:title" content="Terms | Oliver Rose Finance">
+  <meta property="og:description" content="Terms and conditions for working with Oliver Rose.">
+  <meta property="og:image" content="https://roseaboveaccountancy.co.uk/images/Rose%20Above%20Logo.png">
+  <meta property="og:url" content="https://roseaboveaccountancy.co.uk/terms.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body>
+  <a href="#mainContent" class="skip-link">Skip to main content</a>
   <header>
     <div class="header-content">
       <a href="index.html" class="logo" aria-label="Oli Rose Home">
@@ -28,9 +40,18 @@
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
+      <div class="header-controls">
+        <button id="themeToggleBtn" class="theme-toggle" aria-label="Toggle dark or light mode">
+          <span class="theme-toggle-icon"><i class="fa-solid fa-moon"></i></span>
+          <span class="theme-toggle-text">Dark</span>
+        </button>
+        <button class="hamburger" aria-label="Open navigation menu" aria-expanded="false">
+          <span></span><span></span><span></span>
+        </button>
+      </div>
     </div>
   </header>
-  <main class="main-container" style="max-width:700px;margin:auto;padding:2em 1em;">
+  <main id="mainContent" tabindex="-1" class="main-container" style="max-width:700px;margin:auto;padding:2em 1em;">
     <div class="ska-accent"></div>
     <h1 class="section-title">Terms & Conditions</h1>
     <h2>Website Use</h2>
@@ -86,5 +107,7 @@
       </div>
     </div>
   </footer>
+  <button id="backToTop" aria-label="Back to top"><i class="fa-solid fa-arrow-up"></i></button>
+  <script src="js/main.js?v=20250611" defer></script>
 </body>
 </html>

--- a/thankyou.html
+++ b/thankyou.html
@@ -2,9 +2,23 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-<link rel="canonical" href="https://roseaboveaccountancy.co.uk/thankyou.html" />
+  <link rel="canonical" href="https://roseaboveaccountancy.co.uk/thankyou.html" />
   <title>Thank You!</title>
+  <meta name="description" content="Thank you for getting in touch with Oliver Rose." />
+  <meta name="author" content="Oliver Rose">
+  <meta property="og:title" content="Thank You!">
+  <meta property="og:description" content="Thanks for getting in touch with Oliver Rose.">
+  <meta property="og:image" content="https://roseaboveaccountancy.co.uk/images/Rose%20Above%20Logo.png">
+  <meta property="og:url" content="https://roseaboveaccountancy.co.uk/thankyou.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="images/Rose Above Logo - No Background.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/Rose Above Logo - No Background.png">
+  <link rel="stylesheet" href="css/style.css?v=20250611">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&family=Space+Grotesk:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -30,8 +44,13 @@
   </style>
 </head>
 <body>
+  <a href="#mainContent" class="skip-link">Skip to main content</a>
+  <main id="mainContent" tabindex="-1">
   <h1>Thank You!</h1>
   <p>Your message has been sent successfully. I'll be in touch soon.</p>
   <a href="/">Back to Home</a>
+  </main>
+  <button id="backToTop" aria-label="Back to top"><i class="fa-solid fa-arrow-up"></i></button>
+  <script src="js/main.js?v=20250611" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add open graph metadata to every html page for better SEO
- add skip links, dark-mode toggle, and hamburger menu controls
- include Back to Top button and main.js script on all pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68640c314db8832e9faa653ba85d3daf