### PR TITLE
Restore color scheme and layout tweaks

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -14,8 +14,8 @@
   --text-main: #151515;
   --text-muted: #757575;
   --text-heading: #101114;
-  --accent: #16171c;
-  --accent-hover: #168aad;
+  --accent: #bb4ba2;
+  --accent-hover: #3ee7fa;
   --accent-light: #e9e9e9;
   --accent-faded: #e7e7e7;
   --chequer-light: #fff;
@@ -29,7 +29,7 @@
   --font-main: 'Montserrat', Arial, sans-serif;
   --font-heading: 'Space Grotesk', 'Montserrat', Arial, sans-serif;
   --transition: .19s cubic-bezier(.4,0,.2,1);
-  --input-focus: #168aad;
+  --input-focus: #3ee7fa;
 }
 
 /* ===== DARK THEME ===== */
@@ -568,6 +568,14 @@ section {
   transform: translateY(-8px) scale(1.03);
   background: #f7f7f7;
 }
+#contact .card:last-child {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background: linear-gradient(130deg, #3ee7fa11 40%, #bb4ba211 100%);
+  border-left: 4px solid #3ee7fa55;
+  min-width: 280px;
+}
 .card h3 {
   font-size: 1.17rem;
   color: #16171c;
@@ -1043,6 +1051,22 @@ footer .ska-accent {
   opacity: 0.16;
 }
 .site-footer {background:#181818;color:#fff;text-align:center;padding:2.8rem 1.2rem 1.5rem;margin-top:3.2rem;border-radius:0 0 var(--radius) var(--radius);box-shadow:0 -2px 28px #0002;}
+.footer-main-logo {
+  height: 120px;
+  width: auto;
+  max-width: 400px;
+  display: block;
+  margin: 0 auto 2em auto;
+  border-radius: 20px;
+  box-shadow: none;
+  background: none;
+}
+@media (max-width: 600px) {
+  .footer-main-logo {
+    height: 78px;
+    max-width: 220px;
+  }
+}
 
 /* ===== RESPONSIVE ===== */
 @media (max-width: 1280px) {


### PR DESCRIPTION
## Summary
- change accent colour back to purple
- keep accent hover in cyan and update focus colour
- add styles for centred contact card
- style footer logo consistently across pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68659a1e2b34832eb76fa375d8cf2b4c